### PR TITLE
added extension support to other websites

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -22,7 +22,7 @@
   
     "content_scripts": [
       {
-        "matches": ["*://*.mozilla.org/*"],
+        "matches": ["*://*/*"],
         "js": ["confetti.js"],
         "css": ["viewer.css"]
       }


### PR DESCRIPTION
- Added functionality to other websites (Brightspace, Gradescope, etc.) by changing what `content_script` matches to. 
- Was previously matched only to `mozilla` based websites, has since changed to any
- Closes issue #4 